### PR TITLE
Add support for custom user models in Django 1.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 install:
  - pip install -r requirements-travis.txt
 
-script: 
-  - flake8 django_yubico/
+script:
+  - flake8 django_yubico/ --max-line-length=119
 
 notifications:
   email:

--- a/django_yubico/admin.py
+++ b/django_yubico/admin.py
@@ -7,4 +7,5 @@ class YubicoKeyAdmin(admin.ModelAdmin):
     list_display = ('user', 'device_id', 'client_id', 'secret_key', 'enabled')
     search_fields = ['user', 'device_id', 'client_id']
 
+
 admin.site.register(YubicoKey, YubicoKeyAdmin)

--- a/django_yubico/backends.py
+++ b/django_yubico/backends.py
@@ -1,14 +1,13 @@
 from yubico_client.yubico import Yubico
 from yubico_client.yubico_exceptions import YubicoError
-
 from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import User
 
 from models import YubicoKey
 
-# How much time can pass between the time when the first and last OTP is
-# generated
+
+# How much time can pass between the time when the first and last OTP is generated
 YUBICO_MULTI_TIMEOUT = getattr(settings, 'YUBICO_MULTI_TIMEOUT', 10)
 
 
@@ -16,6 +15,7 @@ class YubicoBackend(object):
     """
     This backend requires a valid username and OTP from user to login.
     """
+
     def authenticate(self, username=None, otp=None):
         if not otp:
             return None
@@ -39,8 +39,7 @@ class YubicoBackend(object):
             if count > 1:
                 # More then 1 OTP provided, using multi mode
                 status = client.verify_multi(otp_list=otp,
-                                             max_time_window=
-                                             YUBICO_MULTI_TIMEOUT)
+                                             max_time_window=YUBICO_MULTI_TIMEOUT)
             else:
                 status = client.verify(otp[0])
         except YubicoError:
@@ -63,6 +62,7 @@ class YubicoBackendStaff(ModelBackend):
     If this backend is enabled, normal users can login with just a password
     but staff and super users are required to enter a valid OTP to log in.
     """
+
     def authenticate(self, *args, **kwargs):
         user = super(YubicoBackendStaff, self).authenticate(*args, **kwargs)
 
@@ -77,6 +77,7 @@ class YubicoBackendRequireYubikey(ModelBackend):
     If this backend is enabled, each user with at least one active YubiKey
     must enter a valid OTP to log in.
     """
+
     def authenticate(self, *args, **kwargs):
         user = super(YubicoBackendRequireYubikey, self).authenticate(*args,
                                                                      **kwargs)

--- a/django_yubico/forms.py
+++ b/django_yubico/forms.py
@@ -75,7 +75,7 @@ class PasswordForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs['user']
-        del(kwargs['user'])
+        del (kwargs['user'])
         super(PasswordForm, self).__init__(*args, **kwargs)
 
     def clean_password(self):

--- a/django_yubico/models.py
+++ b/django_yubico/models.py
@@ -1,5 +1,10 @@
+from django.conf import settings
 from django.db import models
-from django.contrib.auth.models import User
+
+try:
+    User = settings.AUTH_USER_MODEL
+except AttributeError:
+    from django.contrib.auth.models import User
 
 
 class YubicoKey(models.Model):

--- a/django_yubico/templates/django_yubico/login.html
+++ b/django_yubico/templates/django_yubico/login.html
@@ -2,11 +2,11 @@
 
 {% block content %}
 <div id="yubikey_login">
-<h1>{% trans 'Yubikey Login' %}</h1>
-{% trans 'Please touch the Yubikey bottom to login.' %}</p>
-<form action="" method="post" onkeypress="return event.keyCode != 13" id="yubico_form">{% csrf_token %}
-{{ form.as_p }}
-<p><input type="submit" id="yubikey_login_button" value="{% trans 'Log in' %}" /></p>
-</form>
+    <h1>{% trans 'Yubikey Login' %}</h1>
+    {% trans 'Please touch the Yubikey bottom to login.' %}</p>
+    <form action="" method="post" onkeypress="return event.keyCode != 13" id="yubico_form">{% csrf_token %}
+        {{ form.as_p }}
+        <p><input type="submit" id="yubikey_login_button" value="{% trans 'Log in' %}"/></p>
+    </form>
 </div>
 {% endblock %}

--- a/django_yubico/templates/django_yubico/password.html
+++ b/django_yubico/templates/django_yubico/password.html
@@ -2,11 +2,11 @@
 
 {% block content %}
 <div id="yubikey_login">
-<h1>{% trans 'Yubikey Login' %}</h1>
-{% trans 'Please enter your password.' %}</p>
-<form action="" method="post">{% csrf_token %}
-{{ form.as_p }}
-<p><input type="submit" id="yubikey_login_button" value="{% trans 'Log in' %}" /></p>
-</form>
+    <h1>{% trans 'Yubikey Login' %}</h1>
+    {% trans 'Please enter your password.' %}</p>
+    <form action="" method="post">{% csrf_token %}
+        {{ form.as_p }}
+        <p><input type="submit" id="yubikey_login_button" value="{% trans 'Log in' %}"/></p>
+    </form>
 </div>
 {% endblock %}

--- a/django_yubico/views.py
+++ b/django_yubico/views.py
@@ -6,10 +6,10 @@ from django.http import HttpResponseRedirect
 from django.contrib.auth import login as auth_login
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
-
 from django.views.decorators.cache import never_cache
 
 from forms import LoginForm, PasswordForm
+
 
 # Ask for the user password after the token
 YUBIKEY_USE_PASSWORD = getattr(settings, 'YUBICO_USE_PASSWORD', True)
@@ -105,7 +105,7 @@ def password(request, template_name='django_yubico/password.html',
             request.session[YUBIKEY_SESSION_ATTEMPT_COUNTER] += 1
 
             if request.session[YUBIKEY_SESSION_ATTEMPT_COUNTER] > \
-               YUBIKEY_PASSWORD_ATTEMPTS:
+                    YUBIKEY_PASSWORD_ATTEMPTS:
                 # Maximum number of attemps has been reached. Require user to
                 # start from scratch.
                 reset_user_session(session=request.session)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,3 @@
+Django
+yubico-client>=1.9,<1.10
 Sphinx>=1.2b1,<=1.3


### PR DESCRIPTION
Fixes #6. This is backwards compatible with non-custom user models as well.

Minor additions:
- Fixed line length for pep with the normal standard being 120 (updated flake TravisCI config)
- Cleaned up files to meet PEP8 (mostly stuff that flake isn't picky about)
- Updated requirements-dev.txt to include requirements needs for proper module introspection / hinting while developing locally (i.e. get rid of PyCharm snags of missing packages)
